### PR TITLE
Adding links for newly released Logging analytics quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,27 +6,10 @@ This repository has automation for various observability and management services
 
 In this example we will get you started on the Oracle Cloud Infrastructure observability and management journey. This example quickly creates a audit logs dashboard with just one click. 
 
-[![Deploy to Oracle Cloud](https://oci-resourcemanager-plugin.plugins.oci.oraclecloud.com/latest/deploy-to-oracle-cloud.svg)](https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://github.com/oracle-quickstart/oci-observability-and-management/releases/download/3.0/oci-logging-analytics.zip) 
+[![Deploy to Oracle Cloud](https://oci-resourcemanager-plugin.plugins.oci.oraclecloud.com/latest/deploy-to-oracle-cloud.svg)](https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://github.com/oracle-quickstart/oci-observability-and-management/releases/download/la-qs-4.0/oci-log-analytics-v4.2.zip) 
 
 ![Out-of-Box Dashboard for OCI Audit Logs ](https://user-images.githubusercontent.com/80283985/153082162-662ac81b-9e85-483e-93ab-72d6a9cd560d.png)
 
-
-
-## OCI Functions 
-
-Note:
-
-There is a prerequisite to create a Docker image as described in this [README](https://github.com/oracle-quickstart/oci-observability-and-management/blob/master/examples/oci-functions/README.md)
-
-[![Deploy to Oracle Cloud](https://oci-resourcemanager-plugin.plugins.oci.oraclecloud.com/latest/deploy-to-oracle-cloud.svg)](https://cloud.oracle.com/resourcemanager/stacks/create?zipUrl=https://github.com/oracle-quickstart/oci-observability-and-management/releases/download/functionsv1.0/oci-functions.zip) 
-
-Please get inside the individual examples and perform terraform operations. Each example includes its own README to follow.
-
-```
-git clone https://github.com/oracle-quickstart/oci-observability-and-management.git
-cd oci-observability-and-management
-cd examples/oci-logging-analytics
-```
 
 ## Contributing
 


### PR DESCRIPTION
Adding links for new release: https://github.com/oracle-quickstart/oci-observability-and-management/releases/download/la-qs-4.0/oci-log-analytics-v4.2.zip
